### PR TITLE
Use {} logging placeholders

### DIFF
--- a/src/main/java/myapp/controller/MainController.java
+++ b/src/main/java/myapp/controller/MainController.java
@@ -40,7 +40,7 @@ public class MainController implements Initializable {
             controller.stage.setScene(new Scene(node));
 
         } catch (IOException e) {
-            Logger.error(" caught a " + e.getClass() + "\n with message: " + e.getMessage());
+            Logger.error(" caught a {}\n with message: {}", e.getClass(), e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/myapp/services/UserSettingsService.java
+++ b/src/main/java/myapp/services/UserSettingsService.java
@@ -73,7 +73,7 @@ public class UserSettingsService {
             f.close();
 
         } catch (IOException e) {
-            Logger.error(" caught a " + e.getClass() + "\n with message: " + e.getMessage());
+            Logger.error(" caught a {}\n with message: {}", e.getClass(), e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
I think, there should be the "usual" logger pattern be used. This PR makes use of `{}` and also enables outputting the stack strace.

Documentation: https://tinylog.org/logging/